### PR TITLE
build(ci): adds GitHub workflow for build (and test), lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Truework Node.js SDK CI
+
+on:
+  push:
+    branches:
+      - master
+      - next
+  pull_request:
+    branches:
+      - master
+      - next
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Installing dependencies
+        run: npm ci
+      - name: Build & Test
+        run: npm run build
+      - name: Lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "watch": "microbundle watch",
     "build": "microbundle build",
     "test": "ava ./lib/__test__/*.test.ts --verbose",
-    "lint": "prettier-standard ./lib/*.ts --format",
+    "format": "prettier-standard ./lib/*.ts --format",
+    "lint": "prettier-standard ./lib/*.ts",
     "release": "np",
     "postbuild": "npm run test",
     "prerelease": "npm run build"


### PR DESCRIPTION
`npm run test` will be run via the `postbuild` npm hook, so I left it out of the explicit steps of the workflow.