### PR TITLE
fix(lib/types.ts): add type for date_of_completion field

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -193,6 +193,7 @@ export interface Verification {
   target: Target;
   permissible_purpose: PERMISSIBLE_PURPOSES;
   type: VERIFICATION_TYPES;
+  date_of_completion: string | null;
   documents?: Document[];
   additional_information?: string;
   cancellation_reason?: CANCELLATION_REASONS;


### PR DESCRIPTION
Closes #10

This field was added to the API in truework/truework-frontend-api#3866.

### Screenshot
<img width="618" alt="Screen Shot 2020-08-14 at 2 56 48 PM" src="https://user-images.githubusercontent.com/60897327/90288566-bfc6bc80-de3f-11ea-857c-3f783ee7ddb5.png">

