### PR TITLE
fix: replace 'start_date' with 'hired_date' for employees

### DIFF
--- a/lib/mocks/objects.ts
+++ b/lib/mocks/objects.ts
@@ -87,6 +87,7 @@ export const employee: types.Employee = {
   social_security_number: '***-**-1234',
   positions: [position],
   earnings: [earning],
+  hired_date: '2016-02-11',
   salary,
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -146,7 +146,7 @@ export type Employee = {
   last_name: string;
   address: Address;
   status: EMPLOYEE_STATUSES;
-  start_date?: string;
+  hired_date?: string;
   termination_date?: string;
   social_security_number: string;
   earnings?: Earnings[];


### PR DESCRIPTION
We're using `start_date` but the field is actually called `hiring_date`. This commit replaces the
incorrect field with the correct one and resolves the problem.