### PR TITLE
feat: updates to report, salary, employee status, employment type models

### DIFF
--- a/lib/mocks/objects.ts
+++ b/lib/mocks/objects.ts
@@ -1,4 +1,5 @@
 import * as types from '../types';
+import { PAY_REDUCED_COVID } from '../types';
 import * as constants from './constants';
 
 export const error: types.SDKError = {
@@ -63,10 +64,16 @@ export const price: types.Price = {
   currency: 'USD',
 };
 
+export const respondent: types.Respondent = {
+  full_name: 'First Last',
+  title: 'Some Title',
+};
+
 export const salary: types.Salary = {
   gross_pay: '123456.00',
   pay_frequency: 'annually',
   hours_per_week: '40',
+  reduced_covid: PAY_REDUCED_COVID.NO,
 };
 
 export const earning: types.Earnings = {
@@ -136,4 +143,6 @@ export const report: types.ResponseReportGet = {
   },
   employer: employer,
   employee: employee,
+  additional_notes: 'some free form text',
+  respondent: respondent,
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,13 @@ export enum EMPLOYEE_STATUSES {
   ACTIVE = 'active',
   INACTIVE = 'inactive',
   UNKNOWN = 'unknown',
+  FURLOUGHED_COVID = 'furloughed-covid',
+  NON_EMPLOYEE = 'non-employee',
+}
+export enum PAY_REDUCED_COVID {
+  YES = 'yes',
+  NO = 'no',
+  UNKNOWN = 'unknown',
 }
 
 /*
@@ -94,6 +101,8 @@ export type ResponseReportGet = {
   verification_request: ReportVerificationRequest;
   employer: Employer;
   employee: Employee;
+  additional_notes?: string;
+  respondent?: Respondent;
 };
 export type ResponseCompaniesGet = PaginatedResponse<CompanySearchResult>;
 
@@ -164,7 +173,8 @@ export type Position = {
     | 'regular-full-time'
     | 'regular-part-time'
     | 'contractor'
-    | 'other';
+    | 'other'
+    | 'no-answer';
 };
 export type Price = {
   amount: string;
@@ -175,10 +185,15 @@ export type ReportVerificationRequest = {
   created: string;
   id: string;
 };
+export type Respondent = {
+  full_name?: string;
+  title?: string;
+};
 export type Salary = {
   gross_pay: string;
   pay_frequency: string;
   hours_per_week: string;
+  reduced_covid?: PAY_REDUCED_COVID;
 };
 export type Target = {
   first_name: string;


### PR DESCRIPTION
BREAKING CHANGE: Addition of new enum values is backwards incompatible

Backwards compatible changes:
- Adding additional_notes and respondent to report model
- Adding reduced_covid to Salary model

Backwards incompatible changes:
- Addition of new enum values to employee.status
- Addition of new enum values to employee.position.employment_type