### PR TITLE
feat: backwards compatible changes to report, salary, target, and verification models

### DIFF
--- a/lib/__test__/mocks.test.ts
+++ b/lib/__test__/mocks.test.ts
@@ -95,6 +95,7 @@ test('verifications.getOne', async t => {
   });
 
   t.is(res.body.id, constants.VALID_VERIFICATION_ID);
+  t.assert(res.body.reports);
 });
 test('verifications.getOne - invalid', async t => {
   const { client } = t.context;

--- a/lib/mocks/objects.ts
+++ b/lib/mocks/objects.ts
@@ -1,5 +1,6 @@
 import * as types from '../types';
 import * as constants from './constants';
+import { PAY_REDUCED_COVID } from '../types';
 
 export const error: types.SDKError = {
   error: {
@@ -63,10 +64,17 @@ export const price: types.Price = {
   currency: 'USD',
 };
 
+export const respondent: types.Respondent = {
+  full_name: 'First Last',
+  title: 'Some Title',
+};
+
 export const salary: types.Salary = {
   gross_pay: '123456.00',
   pay_frequency: 'annually',
   hours_per_week: '40',
+  months_per_year: '4.5',
+  reduced_covid: PAY_REDUCED_COVID.NO,
 };
 
 export const earning: types.Earnings = {
@@ -96,20 +104,6 @@ export const turnaroundTime: types.TurnaroundTime = {
   lower_bound: '2',
 };
 
-export const verification: types.Verification = {
-  id: constants.VALID_VERIFICATION_ID,
-  state: types.VERIFICATION_STATES.PENDING_APPROVAL,
-  price,
-  turnaround_time: turnaroundTime,
-  created: '2020-08-11T15:14:51.444036Z',
-  target: target,
-  permissible_purpose: types.PERMISSIBLE_PURPOSES.EMPLOYMENT,
-  type: types.VERIFICATION_TYPES.VOE,
-  documents: [document],
-  additional_information: 'Notes about the verification',
-  date_of_completion: null,
-};
-
 export const cancelledVerification: types.Verification = {
   id: constants.VALID_VERIFICATION_ID,
   state: types.VERIFICATION_STATES.CANCELED,
@@ -136,4 +130,23 @@ export const report: types.ResponseReportGet = {
   },
   employer: employer,
   employee: employee,
+  respondent: respondent,
+  du_reference_id: '12345',
+  additional_notes: 'some free form text',
+};
+
+export const verification: types.Verification = {
+  id: constants.VALID_VERIFICATION_ID,
+  state: types.VERIFICATION_STATES.PENDING_APPROVAL,
+  price,
+  turnaround_time: turnaroundTime,
+  created: '2020-08-11T15:14:51.444036Z',
+  target: target,
+  permissible_purpose: types.PERMISSIBLE_PURPOSES.EMPLOYMENT,
+  type: types.VERIFICATION_TYPES.VOE,
+  documents: [document],
+  additional_information: 'Notes about the verification',
+  date_of_completion: null,
+  reports: [report],
+  loan_id: '12345',
 };

--- a/lib/mocks/responses.ts
+++ b/lib/mocks/responses.ts
@@ -27,6 +27,9 @@ export const verifications = {
     if (data.additional_information) {
       res.additional_information = data.additional_information;
     }
+    if (data.loan_id) {
+      res.loan_id = data.loan_id;
+    }
 
     return [success ? 201 : 400, success ? res : objects.errorWithFields];
   },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,11 @@ export enum EMPLOYEE_STATUSES {
   INACTIVE = 'inactive',
   UNKNOWN = 'unknown',
 }
+export enum PAY_REDUCED_COVID {
+  YES = 'yes',
+  NO = 'no',
+  UNKNOWN = 'unknown',
+}
 
 /*
  * Generics
@@ -71,6 +76,7 @@ export type RequestVerificationsCreate = {
   target: Target;
   documents?: Document[];
   additional_information?: string;
+  loan_id?: string;
 };
 export type RequestVerificationsGetReport = {
   id: string;
@@ -88,13 +94,7 @@ export type ResponseVerificationsCreate = Verification;
 export type ResponseVerificationsGet = PaginatedResponse<Verification>;
 export type ResponseVerificationsGetOne = Verification;
 export type ResponseVerificationsCancel = string;
-export type ResponseReportGet = {
-  created: string;
-  current_as_of?: string;
-  verification_request: ReportVerificationRequest;
-  employer: Employer;
-  employee: Employee;
-};
+export type ResponseReportGet = Report;
 export type ResponseCompaniesGet = PaginatedResponse<CompanySearchResult>;
 
 /*
@@ -170,22 +170,38 @@ export type Price = {
   amount: string;
   currency: string;
 };
+export type Report = {
+  created: string;
+  current_as_of?: string;
+  verification_request: ReportVerificationRequest;
+  employer: Employer;
+  employee: Employee;
+  additional_notes?: string;
+  respondent?: Respondent;
+  du_reference_id?: string;
+};
 export type ReportVerificationRequest = {
   type: VERIFICATION_TYPES;
   created: string;
   id: string;
 };
+export type Respondent = {
+  full_name?: string;
+  title?: string;
+};
 export type Salary = {
   gross_pay: string;
   pay_frequency: string;
   hours_per_week: string;
+  months_per_year?: string;
+  reduced_covid?: PAY_REDUCED_COVID;
 };
 export type Target = {
   first_name: string;
   last_name: string;
   social_security_number: string;
   contact_email?: string;
-  company: Pick<Company, 'id'> | Pick<Company, 'name'> | Company; // one of id or name is required
+  company?: Pick<Company, 'id'> | Pick<Company, 'name'> | Company;
 };
 export type TurnaroundTime = {
   upper_bound?: string;
@@ -205,4 +221,6 @@ export type Verification = {
   additional_information?: string;
   cancellation_reason?: CANCELLATION_REASONS;
   cancellation_details?: string;
+  loan_id?: string;
+  reports?: Report[];
 };


### PR DESCRIPTION
Report:
  - Adds optional additional notes field
  - Adds optional respondent information
  - Adds optional du reference id

Salary
  - Adds optional months paid in a year
  - Adds optional pay reduced due to covid field

Target
  - Makes company an optional parameter

Verification
  - Adds optional loan id
  - Adds optional array of reports

Verification Create
  - Adds optional loan id